### PR TITLE
[docs] Add missing `require` at GCF tutorial

### DIFF
--- a/docs/tutorials/serverless-pathom-gcf.mdx
+++ b/docs/tutorials/serverless-pathom-gcf.mdx
@@ -82,6 +82,7 @@ for this:
 ```clojure
 (ns com.wsscode.pathom-server
   (:require
+    [cognitect.transit :as t]
     ; to include the env setup from the Tutorial demo
     [com.wsscode.pathom3.demos.ip-weather :refer [env]]
 


### PR DESCRIPTION
Add missing `require` at serverless pathom GCF tutorial.